### PR TITLE
Default for ThumbnailResizeType

### DIFF
--- a/src/model/GalleryHub.php
+++ b/src/model/GalleryHub.php
@@ -47,6 +47,7 @@ class GalleryHub extends Page
         "ThumbnailWidth" => 150,
         "ThumbnailHeight" => 150,
         "ThumbnailsPerPage" => 18,
+        "ThumbnailResizeType" => 'crop',
         "PaddedImageBackground" => "ffffff"
     ];
 


### PR DESCRIPTION
The Enum default does not seem to work, so setting via $defaults. Fixes #7. 