### PR TITLE
Default ImageResizeType, Image reordering, resize-from-template support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "issues": "http://github.com/i-lateral/silverstripe-gallery/issues"
     },
     "require": {
-        "silverstripe/cms": "~4.0"
+        "silverstripe/cms": "^4.1",
+        "bummzack/sortablefile": "^2.0"
     },
     "extra": {
         "expose": [

--- a/src/extensions/GalleryImage.php
+++ b/src/extensions/GalleryImage.php
@@ -7,7 +7,7 @@ use ilateral\SilverStripe\Gallery\Model\GalleryPage;
 
 class GalleryImage extends DataExtension
 {
-    private static $belogs_many_many = [
+    private static $belongs_many_many = [
         'Gallery'   => GalleryPage::class
     ];
 }

--- a/src/model/GalleryPage.php
+++ b/src/model/GalleryPage.php
@@ -37,6 +37,7 @@ class GalleryPage extends GalleryHub
     private static $defaults = [
         "ImageWidth" => 950,
         "ImageHeight" => 500,
+        "ImageResizeType" => 'ratio',
         "ShowSideBar" => 1
     ];
 
@@ -45,7 +46,7 @@ class GalleryPage extends GalleryHub
     ];
 
     private static $many_many_extraFields = [
-        'Images' => array('SortOrder' => 'Int')
+        'Images' => ['SortOrder' => 'Int']
     ];
 
     private static $owns = [

--- a/src/model/GalleryPage.php
+++ b/src/model/GalleryPage.php
@@ -9,7 +9,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\CheckboxField;
-use SilverStripe\AssetAdmin\Forms\UploadField;
+use Bummzack\SortableFile\Forms\SortableUploadField;
 use ilateral\SilverStripe\Gallery\Control\GalleryPageController;
 
 /**
@@ -85,7 +85,7 @@ class GalleryPage extends GalleryHub
             
             $fields->addFieldToTab(
                 "Root.Gallery",
-                UploadField::create(
+                SortableUploadField::create(
                     'Images',
                     $this->fieldLabel('Images')
                 )->setFolderName($upload_folder)


### PR DESCRIPTION
Looks like the same issue as on GalleryHub also happened on GalleryPage, concerning default ResizeType. Also fixed now. (I would personally have handled this in template files, but anyway)

The second commit restores sortability for Images, but it bumps SS version requirement to 4.1 and adds a dependency. Is that okay? Perhaps you were using something else in the past, but the 'native' UploadField does not support reordering, at least not in SS4+.